### PR TITLE
Multiple IP addresses for new devices

### DIFF
--- a/pyiseers.py
+++ b/pyiseers.py
@@ -1760,7 +1760,7 @@ class ERS(object):
     def add_device(
         self,
         name=None,
-        *ip_address=None,
+        ip_address=None,
         mask=32,
         description="",
         dev_group=None,
@@ -1825,22 +1825,31 @@ class ERS(object):
         # If no payload provided, build from provided details
         elif name and ip_address:
             data = {
-                            "NetworkDevice": {
-                                "name": name,
-                                "description": description,
-                                "profileName": dev_profile,
-                                "coaPort": coa_port,
-                                "NetworkDeviceIPList": [
-                                ],
-                                "NetworkDeviceGroupList": [dev_type, dev_location, dev_ipsec],
-                            }
-                        }
-            for ip in ip_address:
+                "NetworkDevice": {
+                    "name": name,
+                    "description": description,
+                    "profileName": dev_profile,
+                    "coaPort": coa_port,
+                    "NetworkDeviceIPList": [
+                    ],
+                    "NetworkDeviceGroupList": [dev_type, dev_location, dev_ipsec],
+                }
+            }
+
+            if type(ip_address) is str:
                 data["NetworkDevice"]["NetworkDeviceIPList"].append(
                     {
-                        "ipaddress": ip,
+                        "ipaddress": ip_address,
                         "mask": mask,
                     })
+
+            elif type(ip_address) is list:
+                for ips in ip_address:
+                    data["NetworkDevice"]["NetworkDeviceIPList"].append(
+                        {
+                            "ipaddress": ips,
+                            "mask": mask,
+                        })
 
             if tacacs_shared_secret is not None:
                 data["NetworkDevice"]["tacacsSettings"] = {

--- a/pyiseers.py
+++ b/pyiseers.py
@@ -1760,7 +1760,7 @@ class ERS(object):
     def add_device(
         self,
         name=None,
-        ip_address=None,
+        *ip_address=None,
         mask=32,
         description="",
         dev_group=None,
@@ -1825,20 +1825,22 @@ class ERS(object):
         # If no payload provided, build from provided details
         elif name and ip_address:
             data = {
-                "NetworkDevice": {
-                    "name": name,
-                    "description": description,
-                    "profileName": dev_profile,
-                    "coaPort": coa_port,
-                    "NetworkDeviceIPList": [
-                        {
-                            "ipaddress": ip_address,
-                            "mask": mask,
+                            "NetworkDevice": {
+                                "name": name,
+                                "description": description,
+                                "profileName": dev_profile,
+                                "coaPort": coa_port,
+                                "NetworkDeviceIPList": [
+                                ],
+                                "NetworkDeviceGroupList": [dev_type, dev_location, dev_ipsec],
+                            }
                         }
-                    ],
-                    "NetworkDeviceGroupList": [dev_type, dev_location, dev_ipsec],
-                }
-            }
+            for ip in ip_address:
+                data["NetworkDevice"]["NetworkDeviceIPList"].append(
+                    {
+                        "ipaddress": ip,
+                        "mask": mask,
+                    })
 
             if tacacs_shared_secret is not None:
                 data["NetworkDevice"]["tacacsSettings"] = {


### PR DESCRIPTION
This change allows the parameter 'ip_address' (in the function 'add_device') to be either a list or string. With this you can create a device with multiple IP addresses.